### PR TITLE
Fixes for deployment workflows

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,11 +1,11 @@
-name: Deploy to Heroku
+name: Deploy to Heroku production
 
 on:
   workflow_run:
     workflows:
       - Test
     branches:
-      - develop
+      - main
     types:
       - completed
   workflow_dispatch:
@@ -13,11 +13,11 @@ on:
 env:
   # To API Key is used by Heroku CLI to authenticate
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
+  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME_PRODUCTION }}
 
 jobs:
   deploy:
-    name: Deploy to Heroku
+    name: Deploy to Heroku production
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,39 @@
+name: Deploy to Heroku staging
+
+on:
+  workflow_run:
+    workflows:
+      - Test
+    branches:
+      - develop
+    types:
+      - completed
+  workflow_dispatch:
+
+env:
+  # To API Key is used by Heroku CLI to authenticate
+  HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME_STAGING }}
+
+jobs:
+  deploy:
+    name: Deploy to Heroku staging
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Heroku Container registry
+        run: heroku container:login
+
+      - name: Build and push
+        run: heroku container:push -a ${{ env.HEROKU_APP_NAME }} web
+
+      - name: Release
+        run: heroku container:release -a ${{ env.HEROKU_APP_NAME }} web

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test
 
-on: pull_request
+on: push
 
 env:
   OTP_VERSION: "24.2.2"


### PR DESCRIPTION
Resolves #25

## What happened

The initial CD deployment configuration didn't work, because it was supposed to be run after all tests in the branch pass, but we didn't run tests on the `push` event, we ran them only on the `pull request` event.

This PR fixing it, and now after you merge PR to the branch all tests will be run and deployment will be triggered (at least I hope so).

Also, I noticed that there are requirements to set both staging and production servers, so a new workflow for production deployment was added.
 
