### PR TITLE
[#45] Fix failing deployment workflow

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,7 @@ defmodule GoogleScraping.MixProject do
       {:faker, "~> 0.17.0", [only: [:dev, :test], runtime: false]},
       {:floki, ">= 0.30.0", only: :test},
       {:gettext, "~> 0.18"},
+      {:httpoison, "~> 1.8.1"},
       {:jason, "~> 1.2"},
       {:mimic, "~> 1.7.2", [only: :test]},
       {:nimble_csv, "~> 1.2.0"},


### PR DESCRIPTION
Resolves #45

## What happened 👀

Missed lib was added to the `mix.exs` file.

## Insight 📝

`HTTPoison` lib was missed in the project dependencies, which is why Docker couldn't build a container.

It worked fine on CI because `HTTPoison` is a dev dependency for some libs, and we run tests in dev mode,

## Proof Of Work 📹

Manually triggered action worked without issues: https://github.com/Nihisil/nimble-certification-elixir/actions/runs/2513048991
