### PR TITLE
[#17] [Backend] As a user, I can see the details page for a specific keyword

### DIFF
--- a/lib/google_scraping/dashboard/keywords.ex
+++ b/lib/google_scraping/dashboard/keywords.ex
@@ -68,6 +68,9 @@ defmodule GoogleScraping.Dashboard.Keywords do
     end)
   end
 
+  def get_user_keyword_by_id!(%User{id: user_id} = _user, keyword_id),
+    do: Repo.get_by!(Keyword, id: keyword_id, user_id: user_id)
+
   @doc """
   Gets a single keyword.
   """

--- a/lib/google_scraping/dashboard/keywords.ex
+++ b/lib/google_scraping/dashboard/keywords.ex
@@ -68,7 +68,7 @@ defmodule GoogleScraping.Dashboard.Keywords do
     end)
   end
 
-  def get_user_keyword_by_id!(%User{id: user_id} = _user, keyword_id),
+  def get_user_keyword_by_id!(%User{id: user_id}, keyword_id),
     do: Repo.get_by!(Keyword, id: keyword_id, user_id: user_id)
 
   @doc """

--- a/lib/google_scraping_web/controllers/keyword_controller.ex
+++ b/lib/google_scraping_web/controllers/keyword_controller.ex
@@ -26,7 +26,7 @@ defmodule GoogleScrapingWeb.KeywordController do
       |> redirect(to: Routes.keyword_path(conn, :index))
     else
       %Ecto.Changeset{valid?: false} ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        show_error_flash_message_and_redirects_to_dashboard(
           conn,
           gettext("The file doesn't look like CSV.")
         )
@@ -36,16 +36,21 @@ defmodule GoogleScrapingWeb.KeywordController do
     end
   end
 
+  def show(conn, %{"id" => keyword_id}) do
+    keyword = Keywords.get_user_keyword_by_id!(conn.assigns.current_user, keyword_id)
+    render(conn, "show.html", keyword: keyword)
+  end
+
   defp process_validation_error(conn, reason) do
     case reason do
       :empty_file_error ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        show_error_flash_message_and_redirects_to_dashboard(
           conn,
           gettext("The file is empty.")
         )
 
       :file_is_too_long_error ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        show_error_flash_message_and_redirects_to_dashboard(
           conn,
           gettext("The file is too big, allowed size is up to %{limit} keywords.",
             limit: KeywordCSVFile.keywords_limit()
@@ -53,7 +58,7 @@ defmodule GoogleScrapingWeb.KeywordController do
         )
 
       :one_or_more_keywords_are_invalid ->
-        show_error_flash_message_and_redirects_to_dasboard(
+        show_error_flash_message_and_redirects_to_dashboard(
           conn,
           gettext("One or more keywords are invalid! Allowed keyword length is %{min}-%{max}",
             min: Keyword.min_length(),
@@ -63,7 +68,7 @@ defmodule GoogleScrapingWeb.KeywordController do
     end
   end
 
-  defp show_error_flash_message_and_redirects_to_dasboard(conn, flash_message) do
+  defp show_error_flash_message_and_redirects_to_dashboard(conn, flash_message) do
     conn
     |> put_flash(:error, flash_message)
     |> redirect(to: Routes.keyword_path(conn, :index))

--- a/lib/google_scraping_web/router.ex
+++ b/lib/google_scraping_web/router.ex
@@ -76,6 +76,6 @@ defmodule GoogleScrapingWeb.Router do
     pipe_through [:browser, :require_authenticated_user]
 
     delete "/users/log_out", UserSessionController, :delete
-    resources "/keywords", KeywordController, only: [:index, :create]
+    resources "/keywords", KeywordController, only: [:index, :create, :show]
   end
 end

--- a/lib/google_scraping_web/templates/keyword/index.html.heex
+++ b/lib/google_scraping_web/templates/keyword/index.html.heex
@@ -59,7 +59,9 @@
         <%= for {keyword, i} <- Enum.with_index(@keywords, 1) do %>
           <tr>
             <td><%= i %></td>
-            <td><%= keyword.name %></td>
+            <td>
+              <%= link(keyword.name, to: Routes.keyword_path(@conn, :show, keyword)) %>
+            </td>
             <td><%= keyword.status %></td>
             <td><%= Calendar.strftime(keyword.updated_at, "%Y-%m-%d %H:%M") %></td>
           </tr>

--- a/lib/google_scraping_web/templates/keyword/show.html.heex
+++ b/lib/google_scraping_web/templates/keyword/show.html.heex
@@ -1,0 +1,3 @@
+<h2>Keywords details <%= @keyword.name %></h2>
+
+<p>Coming soon!</p>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -138,17 +138,17 @@ msgid "The file doesn't look like CSV."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:44
+#: lib/google_scraping_web/controllers/keyword_controller.ex:49
 msgid "The file is empty."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:50
+#: lib/google_scraping_web/controllers/keyword_controller.ex:55
 msgid "The file is too big, allowed size is up to %{limit} keywords."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:58
+#: lib/google_scraping_web/controllers/keyword_controller.ex:63
 msgid "One or more keywords are invalid! Allowed keyword length is %{min}-%{max}"
 msgstr ""
 

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -139,17 +139,17 @@ msgid "The file doesn't look like CSV."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:44
+#: lib/google_scraping_web/controllers/keyword_controller.ex:49
 msgid "The file is empty."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:50
+#: lib/google_scraping_web/controllers/keyword_controller.ex:55
 msgid "The file is too big, allowed size is up to %{limit} keywords."
 msgstr ""
 
 #, elixir-autogen, elixir-format
-#: lib/google_scraping_web/controllers/keyword_controller.ex:58
+#: lib/google_scraping_web/controllers/keyword_controller.ex:63
 msgid "One or more keywords are invalid! Allowed keyword length is %{min}-%{max}"
 msgstr ""
 

--- a/test/google_scraping/dashboard/keywords_test.exs
+++ b/test/google_scraping/dashboard/keywords_test.exs
@@ -53,4 +53,24 @@ defmodule GoogleScraping.Dashboard.KeywordsTest do
       assert Keywords.list_keywords(user.id) == []
     end
   end
+
+  describe "get_user_keyword_by_id/1" do
+    test "with valid data, returns a user keyword" do
+      user = insert(:user)
+      keyword = insert(:keyword, user_id: user.id)
+
+      %{id: keyword_id} = Keywords.get_user_keyword_by_id!(user, keyword.id)
+      assert keyword.id == keyword_id
+    end
+
+    test "when trying to load keyword for another user, raises NoResultsError" do
+      user = insert(:user)
+      another_user = insert(:user)
+      keyword = insert(:keyword, user_id: user.id)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Keywords.get_user_keyword_by_id!(another_user, keyword.id)
+      end
+    end
+  end
 end

--- a/test/google_scraping_web/controllers/keyword_controller_test.exs
+++ b/test/google_scraping_web/controllers/keyword_controller_test.exs
@@ -90,7 +90,11 @@ defmodule GoogleScrapingWeb.KeywordControllerTest do
     test "when given auth user and keyword, renders keywords details page", %{conn: conn} do
       user = insert(:user)
       keyword = insert(:keyword, user_id: user.id, name: "test keyword")
-      conn = conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :show, keyword))
+
+      conn =
+        conn
+        |> log_in_user(user)
+        |> get(Routes.keyword_path(conn, :show, keyword))
 
       assert html_response(conn, 200) =~ keyword.name
     end

--- a/test/google_scraping_web/controllers/keyword_controller_test.exs
+++ b/test/google_scraping_web/controllers/keyword_controller_test.exs
@@ -2,14 +2,14 @@ defmodule GoogleScrapingWeb.KeywordControllerTest do
   use GoogleScrapingWeb.ConnCase
 
   describe "GET index/2" do
-    test "when given auth user, renders list of keywords page ", %{conn: conn} do
+    test "when given auth user, renders list of keywords page", %{conn: conn} do
       user = insert(:user)
       conn = conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :index))
 
       assert html_response(conn, 200) =~ "Keywords"
     end
 
-    test "when given NOT auth user, redirects to login page ", %{conn: conn} do
+    test "when given NOT auth user, redirects to login page", %{conn: conn} do
       conn = get(conn, Routes.keyword_path(conn, :index))
 
       assert html_response(conn, 302) =~ "/log_in"
@@ -83,6 +83,33 @@ defmodule GoogleScrapingWeb.KeywordControllerTest do
 
       assert get_flash(conn, :error) ==
                "One or more keywords are invalid! Allowed keyword length is 1-100"
+    end
+  end
+
+  describe "GET show/2" do
+    test "when given auth user and keyword, renders keywords details page", %{conn: conn} do
+      user = insert(:user)
+      keyword = insert(:keyword, user_id: user.id, name: "test keyword")
+      conn = conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :show, keyword))
+
+      assert html_response(conn, 200) =~ keyword.name
+    end
+
+    test "when given NOT auth user, redirects to login page", %{conn: conn} do
+      keyword = insert(:keyword)
+      conn = get(conn, Routes.keyword_path(conn, :show, keyword))
+
+      assert html_response(conn, 302) =~ "/log_in"
+    end
+
+    test "when given another user keyword, shows not found error", %{conn: conn} do
+      another_user = insert(:user)
+      keyword = insert(:keyword, user_id: another_user.id)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        user = insert(:user)
+        conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :show, keyword))
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #17

## What happened 👀

Added new page to display keyword details information.

## Insight 📝

If a user tries to open the keyword page from another user, the page will show a not found error page.

## Proof Of Work 📹

Keyword in the table now are clickable:

<img width="245" alt="image" src="https://user-images.githubusercontent.com/475367/177971260-5546ca02-05b0-410d-81eb-38eff7f76478.png">

If you click on the keyword, the keyword details page will be shown (more details on the page will be added in separate PR):

<img width="317" alt="image" src="https://user-images.githubusercontent.com/475367/177971706-8331a29f-3078-491a-a4ae-108ac503e1b7.png">


