### PR TITLE
[#20] [Frontend] As a user, I can see the details page for a specific keyword

### DIFF
--- a/assets/css/vendor/_bootstrap.scss
+++ b/assets/css/vendor/_bootstrap.scss
@@ -17,12 +17,12 @@
 @import 'bootstrap/scss/tables';
 @import 'bootstrap/scss/forms';
 @import 'bootstrap/scss/buttons';
-// @import 'bootstrap/scss/transitions';
+@import 'bootstrap/scss/transitions';
 @import 'bootstrap/scss/dropdown';
 // @import 'bootstrap/scss/button-group';
 @import 'bootstrap/scss/nav';
 @import 'bootstrap/scss/navbar';
-// @import 'bootstrap/scss/card';
+@import 'bootstrap/scss/card';
 // @import 'bootstrap/scss/accordion';
 @import 'bootstrap/scss/breadcrumb';
 // @import 'bootstrap/scss/pagination';

--- a/lib/google_scraping_web/templates/keyword/show.html.heex
+++ b/lib/google_scraping_web/templates/keyword/show.html.heex
@@ -29,7 +29,7 @@
         </dt>
         <dd class="col-lg-4"><%= @keyword.ad_total_count %></dd>
         <dt class="offset-sm-3 col-lg-5">
-          <%= gettext("URLs of the AdWords advertisers in the top position") %>
+          <%= gettext("Number of AdWords advertiser's URLs in the top position") %>
         </dt>
         <dd class="col-lg-4"><%= @keyword.ad_top_urls_count %></dd>
         <dt class="offset-sm-3 col-lg-5">
@@ -37,7 +37,7 @@
         </dt>
         <dd class="col-lg-4"><%= @keyword.non_ad_results_count %></dd>
         <dt class="offset-sm-3 col-lg-5">
-          <%= gettext("URLs of the non-AdWords results on the page") %>
+          <%= gettext("Number of non-AdWords advertiser's URLs") %>
         </dt>
         <dd class="col-lg-4"><%= @keyword.non_ad_results_urls_count %></dd>
         <dt class="offset-sm-3 col-lg-5">

--- a/lib/google_scraping_web/templates/keyword/show.html.heex
+++ b/lib/google_scraping_web/templates/keyword/show.html.heex
@@ -1,3 +1,73 @@
-<h2>Keywords details <%= @keyword.name %></h2>
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">
+      <%= link(gettext("Keywords"),
+        to: Routes.keyword_path(@conn, :index)
+      ) %>
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">
+      <%= gettext("Keyword '%{name}' details", %{name: @keyword.name}) %>
+    </li>
+  </ol>
+</nav>
 
-<p>Coming soon!</p>
+<div class="card">
+  <div class="card-header text-center">
+    <h2><%= @keyword.name %></h2>
+  </div>
+  <div class="card-body">
+    <dl class="row">
+      <dt class="offset-sm-3 col-lg-5"><%= gettext("Status") %></dt>
+      <dd class="col-lg-4"><%= @keyword.status %></dd>
+      <%= if @keyword.status == :completed do %>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("Number of AdWords advertisers in the top position") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.ad_top_count %></dd>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("The total number of AdWords advertisers on the page") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.ad_total_count %></dd>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("URLs of the AdWords advertisers in the top position") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.ad_top_urls_count %></dd>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("Number of the non-AdWords results on the page") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.non_ad_results_count %></dd>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("URLs of the non-AdWords results on the page") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.non_ad_results_urls_count %></dd>
+        <dt class="offset-sm-3 col-lg-5">
+          <%= gettext("The total number of links (all of them) on the page") %>
+        </dt>
+        <dd class="col-lg-4"><%= @keyword.total_urls_count %></dd>
+      <% end %>
+    </dl>
+    <%= if @keyword.status == :completed do %>
+      <p>
+        <button
+          class="btn btn-primary"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#collapseHTML"
+          aria-expanded="false"
+          aria-controls="collapseHTML"
+        >
+          <%= gettext("Click to see rendered HTML") %>
+        </button>
+      </p>
+      <div>
+        <div class="collapse collapse-horizontal" id="collapseHTML">
+          <iframe {%{srcdoc: @keyword.html}} title="Search results" height="600px" width="100%">
+          </iframe>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <div class="card-footer text-muted text-center">
+    <%= Calendar.strftime(@keyword.updated_at, "%Y-%m-%d %H:%M") %>
+  </div>
+</div>

--- a/lib/google_scraping_web/templates/keyword/show.html.heex
+++ b/lib/google_scraping_web/templates/keyword/show.html.heex
@@ -19,7 +19,7 @@
     <dl class="row">
       <dt class="offset-sm-3 col-lg-5"><%= gettext("Status") %></dt>
       <dd class="col-lg-4"><%= @keyword.status %></dd>
-      <%= if @keyword.status == :completed do %>
+      <%= if is_completed(@keyword) do %>
         <dt class="offset-sm-3 col-lg-5">
           <%= gettext("Number of AdWords advertisers in the top position") %>
         </dt>
@@ -46,7 +46,7 @@
         <dd class="col-lg-4"><%= @keyword.total_urls_count %></dd>
       <% end %>
     </dl>
-    <%= if @keyword.status == :completed do %>
+    <%= if is_completed(@keyword) do %>
       <p>
         <button
           class="btn btn-primary"

--- a/lib/google_scraping_web/views/keyword_view.ex
+++ b/lib/google_scraping_web/views/keyword_view.ex
@@ -1,3 +1,5 @@
 defmodule GoogleScrapingWeb.KeywordView do
   use GoogleScrapingWeb, :view
+
+  def is_completed(keyword), do: keyword.status == :completed
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -211,10 +211,10 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/show.html.heex:32
-msgid "URLs of the AdWords advertisers in the top position"
+msgid "Number of AdWords advertiser's URLs in the top position"
 msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/show.html.heex:40
-msgid "URLs of the non-AdWords results on the page"
+msgid "Number of non-AdWords advertiser's URLs"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -58,6 +58,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:3
+#: lib/google_scraping_web/templates/keyword/show.html.heex:4
 msgid "Keywords"
 msgstr ""
 
@@ -74,6 +75,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:54
+#: lib/google_scraping_web/templates/keyword/show.html.heex:20
 msgid "Status"
 msgstr ""
 
@@ -175,4 +177,44 @@ msgstr ""
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:30
 msgid "or visit index page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:59
+msgid "Click to see rendered HTML"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:9
+msgid "Keyword '%{name}' details"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:24
+msgid "Number of AdWords advertisers in the top position"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:36
+msgid "Number of the non-AdWords results on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:28
+msgid "The total number of AdWords advertisers on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:44
+msgid "The total number of links (all of them) on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:32
+msgid "URLs of the AdWords advertisers in the top position"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:40
+msgid "URLs of the non-AdWords results on the page"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -59,6 +59,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:3
+#: lib/google_scraping_web/templates/keyword/show.html.heex:4
 msgid "Keywords"
 msgstr ""
 
@@ -75,6 +76,7 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:54
+#: lib/google_scraping_web/templates/keyword/show.html.heex:20
 msgid "Status"
 msgstr ""
 
@@ -176,4 +178,44 @@ msgstr ""
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/index.html.heex:30
 msgid "or visit index page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:59
+msgid "Click to see rendered HTML"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:9
+msgid "Keyword '%{name}' details"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:24
+msgid "Number of AdWords advertisers in the top position"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:36
+msgid "Number of the non-AdWords results on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:28
+msgid "The total number of AdWords advertisers on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:44
+msgid "The total number of links (all of them) on the page"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:32
+msgid "URLs of the AdWords advertisers in the top position"
+msgstr ""
+
+#, elixir-autogen, elixir-format
+#: lib/google_scraping_web/templates/keyword/show.html.heex:40
+msgid "URLs of the non-AdWords results on the page"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -212,10 +212,10 @@ msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/show.html.heex:32
-msgid "URLs of the AdWords advertisers in the top position"
+msgid "Number of AdWords advertiser's URLs in the top position"
 msgstr ""
 
 #, elixir-autogen, elixir-format
 #: lib/google_scraping_web/templates/keyword/show.html.heex:40
-msgid "URLs of the non-AdWords results on the page"
+msgid "Number of non-AdWords advertiser's URLs"
 msgstr ""

--- a/test/google_scraping_web/controllers/keyword_controller_test.exs
+++ b/test/google_scraping_web/controllers/keyword_controller_test.exs
@@ -89,10 +89,20 @@ defmodule GoogleScrapingWeb.KeywordControllerTest do
   describe "GET show/2" do
     test "when given auth user and keyword, renders keywords details page", %{conn: conn} do
       user = insert(:user)
-      keyword = insert(:keyword, user_id: user.id, name: "test keyword")
-      conn = conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :show, keyword))
 
-      assert html_response(conn, 200) =~ keyword.name
+      keyword =
+        insert(:keyword,
+          user_id: user.id,
+          name: "test keyword",
+          status: :completed,
+          ad_total_count: 100
+        )
+
+      conn = conn |> log_in_user(user) |> get(Routes.keyword_path(conn, :show, keyword))
+      response = html_response(conn, 200)
+
+      assert response =~ keyword.name
+      assert response =~ "#{keyword.ad_total_count}"
     end
 
     test "when given NOT auth user, redirects to login page", %{conn: conn} do


### PR DESCRIPTION
Resolves #20

## What happened 👀

A new keyword details page was implemented. It displays stat for scarped keyword and allows to see original HTML from google.

## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/475367/178790390-f6f9f025-e1d1-4d45-8b3d-689c170a7747.png)

